### PR TITLE
Update riken-ra.yml

### DIFF
--- a/_data/program/riken-ra.yml
+++ b/_data/program/riken-ra.yml
@@ -1,9 +1,9 @@
-abbr-name: 理研RA
+abbr-name: 理研JRA
 full-name: 大学院生リサーチ・アソシエイト
 month: 10月
 url : https://www.riken.jp/careers/programs/jra/index.html
 organizer: 理化学研究所
-living_funding: 240万円
+living_funding: 300万円
 research_funding: なし
 duration: 1年<br>（標準修業年限まで再契約可）
 eligible_person: 博士課程学生（在籍先が連携大学院・理研と共同研究中・研究協力協定ありのいずれかであること）


### PR DESCRIPTION
表記を「理研RA」から正式な略称である「理研JRA」に修正させていただきました。また、給与は2026年度から月額250,000円になるので更新しました。（参考情報：[https://www.riken.jp/careers/programs/jra/jra2026/](https://www.riken.jp/careers/programs/jra/jra2026/)）